### PR TITLE
Tunnel temporary go path to makefile for gitlab-shell.

### DIFF
--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -88,12 +88,11 @@ chown -R ${GITLAB_USER}: ${GITLAB_SHELL_INSTALL_DIR}
 
 cd ${GITLAB_SHELL_INSTALL_DIR}
 exec_as_git cp -a config.yml.example config.yml
-if [[ -x ./bin/compile ]]; then
-  echo "Compiling gitlab-shell golang executables..."
-  ./bin/compile
-  rm -rf go_build
-fi
-./bin/install
+
+echo "Compiling gitlab-shell golang executables..."
+sed -i '1s|^|export PATH := '"${GOROOT}"'\/bin:$(PATH)\n\n|' Makefile
+exec_as_git make setup
+rm -rf go_build
 
 # remove unused repositories directory created by gitlab-shell install
 rm -rf ${GITLAB_HOME}/repositories

--- a/assets/build/install.sh
+++ b/assets/build/install.sh
@@ -90,9 +90,8 @@ cd ${GITLAB_SHELL_INSTALL_DIR}
 exec_as_git cp -a config.yml.example config.yml
 
 echo "Compiling gitlab-shell golang executables..."
-sed -i '1s|^|export PATH := '"${GOROOT}"'\/bin:$(PATH)\n\n|' Makefile
-exec_as_git make setup
-rm -rf go_build
+exec_as_git bundle install -j"$(nproc)" --deployment --with development test
+exec_as_git "PATH=$PATH" make verify setup
 
 # remove unused repositories directory created by gitlab-shell install
 rm -rf ${GITLAB_HOME}/repositories


### PR DESCRIPTION
Hi,

regarding PR #2066 here are the minimal changes to be able to compile the gitlab-shell.

Kind regards

P.S.: I guess the line including `rm -rf go_build` can be omitted.